### PR TITLE
(GH-16) Target .NET Standard 2.0 and build against Cake 0.26.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -29,8 +29,8 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
     <file src="net46\Cake.Issues.MsBuild.dll" target="lib\net46" />
     <file src="net46\Cake.Issues.MsBuild.pdb" target="lib\net46" />
     <file src="net46\Cake.Issues.MsBuild.xml" target="lib\net46" />
-    <file src="netstandard1.6\Cake.Issues.MsBuild.dll" target="lib\netstandard1.6" />
-    <file src="netstandard1.6\Cake.Issues.MsBuild.pdb" target="lib\netstandard1.6" />
-    <file src="netstandard1.6\Cake.Issues.MsBuild.xml" target="lib\netstandard1.6" />
+    <file src="netstandard2.0\Cake.Issues.MsBuild.dll" target="lib\netstandard2.0" />
+    <file src="netstandard2.0\Cake.Issues.MsBuild.pdb" target="lib\netstandard2.0" />
+    <file src="netstandard2.0\Cake.Issues.MsBuild.xml" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
-    <PackageReference Include="Cake.Testing" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
+    <PackageReference Include="Cake.Testing" Version="0.26.0" />
     <PackageReference Include="Cake.Issues" Version="0.2.0-beta0002" />
     <PackageReference Include="Cake.Issues.Testing" Version="0.2.0-beta0002" />
     <PackageReference Include="Shouldly" Version="2.8.3" />

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
     <PackageReference Include="Cake.Issues" Version="0.2.0-beta0002" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="Microsoft.AnalyzerPowerPack" Version="1.1.0" />

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <Description>MsBuild support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>
@@ -15,12 +15,12 @@
     <CodeAnalysisRuleSet>..\Cake.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.6|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard1.6\Cake.Issues.MsBuild.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.MsBuild.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.6|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.6\Cake.Issues.MsBuild.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.MsBuild.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net46|AnyCPU'">


### PR DESCRIPTION
Target .NET Standard 2.0 and build against Cake 0.26.0

Fixes #16 