### PR TITLE
(GH-21) Update link to CA rules to docs.microsoft.com

### DIFF
--- a/src/Cake.Issues.MsBuild.Tests/MsBuildRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/MsBuildRuleUrlResolverTests.cs
@@ -40,7 +40,7 @@
             }
 
             [Theory]
-            [InlineData("CA2201", "https://www.google.im/search?q=\"CA2201:\"+site:msdn.microsoft.com")]
+            [InlineData("CA2201", "https://www.google.com/search?q=\"CA2201:\"+site:docs.microsoft.com")]
             [InlineData("SA1652", "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1652.md")]
             public void Should_Resolve_Url(string rule, string expectedUrl)
             {

--- a/src/Cake.Issues.MsBuild/MsBuildRuleUrlResolver.cs
+++ b/src/Cake.Issues.MsBuild/MsBuildRuleUrlResolver.cs
@@ -19,7 +19,7 @@
             // Add resolver for common known issue categories.
             this.AddUrlResolver(x =>
                 x.Category.ToUpperInvariant() == "CA" ?
-                    new Uri("https://www.google.im/search?q=%22" + x.Rule + ":%22+site:msdn.microsoft.com") :
+                    new Uri("https://www.google.com/search?q=%22" + x.Rule + ":%22+site:docs.microsoft.com") :
                     null);
             this.AddUrlResolver(x =>
                 x.Category.ToUpperInvariant() == "SA" ?


### PR DESCRIPTION
Update link to CA rules to docs.microsoft.com

Fixes #21 