### PR TITLE
Multitarget .NET Framework 4.7.2 / .NET Core 2.1

### DIFF
--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -28,12 +28,18 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.MsBuild.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.MsBuild.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.MsBuild.xml" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\StructuredLogger.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Microsoft.Build.Framework.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Microsoft.Build.Utilities.Core.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\System.Collections.Immutable.dll" target="lib\netstandard2.0" />
+    <file src="netcoreapp2.1\Cake.Issues.MsBuild.dll" target="lib\netcoreapp2.1" />
+    <file src="netcoreapp2.1\Cake.Issues.MsBuild.pdb" target="lib\netcoreapp2.1" />
+    <file src="netcoreapp2.1\Cake.Issues.MsBuild.xml" target="lib\netcoreapp2.1" />
+    <file src="netcoreapp2.1\StructuredLogger.dll" target="lib\netcoreapp2.1" />
+    <file src="netcoreapp2.1\Microsoft.Build.Framework.dll" target="lib\netcoreapp2.1" />
+    <file src="netcoreapp2.1\Microsoft.Build.Utilities.Core.dll" target="lib\netcoreapp2.1" />
+    <file src="net472\Cake.Issues.MsBuild.dll" target="lib\net472" />
+    <file src="net472\Cake.Issues.MsBuild.pdb" target="lib\net472" />
+    <file src="net472\Cake.Issues.MsBuild.xml" target="lib\net472" />
+    <file src="net472\StructuredLogger.dll" target="lib\net472" />
+    <file src="net472\Microsoft.Build.Framework.dll" target="lib\net472" />
+    <file src="net472\Microsoft.Build.Utilities.Core.dll" target="lib\net472" />
+    <file src="net472\System.Collections.Immutable.dll" target="lib\net472" />
   </files>
 </package>

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
     <Description>MsBuild support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>
@@ -16,12 +16,20 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.MsBuild.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
+    <DocumentationFile>bin\Debug\netcoreapp2.1\Cake.Issues.MsBuild.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.MsBuild.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
+    <DocumentationFile>bin\Debug\net472\Cake.Issues.MsBuild.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.1|AnyCPU'">
+    <DocumentationFile>bin\Release\netcoreapp2.1\Cake.Issues.MsBuild.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
+    <DocumentationFile>bin\Release\net472\Cake.Issues.MsBuild.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multitarget .NET Framework 4.7.2 / .NET Core 2.1 instead of .NET Standard 2.0 since this is now a requirement of Microsoft.Build which is required for #178