### PR TITLE
(GH-201) Support parsing of errors in MsBuildXmlFileLoggerFormat

### DIFF
--- a/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
@@ -15,28 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Testfiles\FullLog.binlog" />
-    <None Remove="Testfiles\FullLog.xml" />
-    <None Remove="Testfiles\IssueWithFile.xml" />
-    <None Remove="Testfiles\IssueWithLineZero.xml" />
-    <None Remove="Testfiles\IssueWithOnlyFileName.xml" />
-    <None Remove="Testfiles\IssueWithoutCode.xml" />
-    <None Remove="Testfiles\IssueWithoutFile.xml" />
-    <None Remove="Testfiles\XmlFileLoggerLogFileFormat\IssueWithAbsoluteFileNameAndWithoutTask.xml" />
-    <None Remove="Testfiles\XmlFileLoggerLogFileFormat\IssueWithoutMessage.xml" />
-    <None Remove="Testfiles\XmlFileLoggerLogFileFormat\LogWithControlChars.xml" />
+    <None Remove="Testfiles\**\*" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Testfiles\BinaryLogFileFormat\FullLog.binlog" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\FullLog.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithoutCode.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithFile.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithLineZero.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithOnlyFileName.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithoutMessage.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithoutFile.xml" />
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\LogWithControlChars.xml" />
+    <EmbeddedResource Include="Testfiles\BinaryLogFileFormat\*.binlog" />
+    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\*.xml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,10 +37,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Cake.Issues.MsBuild\Cake.Issues.MsBuild.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Testfiles\XmlFileLoggerLogFileFormat\IssueWithAbsoluteFileNameAndWithoutTask.xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.Issues.MsBuild.Tests/LogFileFormat/XmlFileLoggerLogFileFormatTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/LogFileFormat/XmlFileLoggerLogFileFormatTests.cs
@@ -402,6 +402,62 @@
                     }
                 }
             }
+
+            [Fact]
+            public void Should_Read_Errors()
+            {
+                // Given
+                var fixture = new MsBuildIssuesProviderFixture<XmlFileLoggerLogFileFormat>("IssueWithError.xml");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(1);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                            @"'ConfigurationManager.GetSortedConfigFiles(String)': not all code paths return a value",
+                            "Cake.Issues.MsBuild.MsBuildIssuesProvider",
+                            "MSBuild")
+                        .InProjectOfName(string.Empty)
+                        .InFile(@"src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs", 1311)
+                        .OfRule("CS0161", null)
+                        .WithPriority(IssuePriority.Error));
+            }
+
+            [Fact]
+            public void Should_Read_Both_Warnings_And_Errors()
+            {
+                // Given
+                var fixture = new MsBuildIssuesProviderFixture<XmlFileLoggerLogFileFormat>("IssueWithBothWarningAndErrors.xml");
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(2);
+                IssueChecker.Check(
+                    issues[0],
+                    IssueBuilder.NewIssue(
+                            @"Microsoft.Usage : 'ConfigurationManager.GetSortedConfigFiles(String)' creates an exception of type 'ApplicationException', an exception type that is not sufficiently specific and should never be raised by user code. If this exception instance might be thrown, use a different exception type.",
+                            "Cake.Issues.MsBuild.MsBuildIssuesProvider",
+                            "MSBuild")
+                        .InProjectOfName(string.Empty)
+                        .InFile(@"src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs", 1311)
+                        .OfRule("CA2201", new Uri("https://www.google.com/search?q=\"CA2201:\"+site:docs.microsoft.com"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    issues[1],
+                    IssueBuilder.NewIssue(
+                            @"'ConfigurationManager.GetSortedConfigFiles(String)': not all code paths return a value",
+                            "Cake.Issues.MsBuild.MsBuildIssuesProvider",
+                            "MSBuild")
+                        .InProjectOfName(string.Empty)
+                        .InFile(@"src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs", 1311)
+                        .OfRule("CS0161", null)
+                        .WithPriority(IssuePriority.Error));
+            }
         }
     }
 }

--- a/src/Cake.Issues.MsBuild.Tests/Testfiles/XmlFileLoggerLogFileFormat/IssueWithBothWarningAndErrors.xml
+++ b/src/Cake.Issues.MsBuild.Tests/Testfiles/XmlFileLoggerLogFileFormat/IssueWithBothWarningAndErrors.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<build started="3/7/2017 8:31:20 AM">
+  <warning code="CA2201" file="src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs" line="1311" column="0"><![CDATA[Microsoft.Usage : 'ConfigurationManager.GetSortedConfigFiles(String)' creates an exception of type 'ApplicationException', an exception type that is not sufficiently specific and should never be raised by user code. If this exception instance might be thrown, use a different exception type.]]></warning>
+  <error code="CS0161" file="src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs" line="1311" column="0"><![CDATA['ConfigurationManager.GetSortedConfigFiles(String)': not all code paths return a value]]></error>
+</build>

--- a/src/Cake.Issues.MsBuild.Tests/Testfiles/XmlFileLoggerLogFileFormat/IssueWithError.xml
+++ b/src/Cake.Issues.MsBuild.Tests/Testfiles/XmlFileLoggerLogFileFormat/IssueWithError.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<build started="3/7/2017 8:31:20 AM">
+  <error code="CS0161" file="src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs" line="1311" column="0"><![CDATA['ConfigurationManager.GetSortedConfigFiles(String)': not all code paths return a value]]></error>
+</build>


### PR DESCRIPTION
Hi

I wanted to annotate our pull requests with build errors but had to make a custom implementation of `XmlFileLoggerLogFileFormat.cs` to make it work. So here is a PR with my changes.

Note that I could not run all tests, because of absolute paths in the log files.

Part of #201