### PR TITLE
Revert "Bump MSBuild.StructuredLogger from 2.1.133 to 2.1.176 in /src"

### DIFF
--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Cake.Core" Version="0.33.0" />
     <PackageReference Include="Cake.Issues" Version="0.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.176" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.0.174" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 


### PR DESCRIPTION
Revert #182, since requirement of .NET 4.7.2 leads to issues with Cake runner for .NET Framework.