### PR TITLE
Migrate from FxCop analyzers to NETAnalyzers

### DIFF
--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.MsBuild.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
@@ -27,7 +28,10 @@
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" />
     <PackageReference Include="Cake.Issues" Version="0.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.0.174" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>


### PR DESCRIPTION
FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'.

Add **AllEnabledByDefault**
Aggressive or opt-out mode, where all rules are enabled by default as build warnings. You can selectively opt out of individual rules to disable them.