### PR TITLE
Update MSBuild.StructuredLogger to the latest version

### DIFF
--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.0.174" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.545" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 


### PR DESCRIPTION
This enables reading the latest binlogs produced by recent versions of MSBuild (including the latest version 14).