### PR TITLE
Cleanup Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,51 +9,16 @@ updates:
   ignore:
   - dependency-name: Cake.Core
     versions:
-    - ">= 0.34.a, < 0.35"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.35.a, < 0.36"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.36.a, < 0.37"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.37.a, < 0.38"
-  - dependency-name: Cake.Core
-    versions:
-    - ">= 0.38.a, < 0.39"
-  - dependency-name: Cake.Core
+    - "> 1.0.0, < 2"
+  - dependency-name: Cake.Testing
     versions:
     - "> 1.0.0, < 2"
   - dependency-name: Cake.Issues
     versions:
-    - "> 0.9.0, < 0.10"
+    - "> 1.0.0, < 2"
   - dependency-name: Cake.Issues.Testing
-    versions:
-    - "> 0.9.0, < 0.10"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.34.a, < 0.35"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.35.a, < 0.36"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.36.a, < 0.37"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.37.a, < 0.38"
-  - dependency-name: Cake.Testing
-    versions:
-    - ">= 0.38.a, < 0.39"
-  - dependency-name: Cake.Testing
     versions:
     - "> 1.0.0, < 2"
   - dependency-name: MSBuild.StructuredLogger
     versions:
-    - 2.1.303
-    - 2.1.364
-    - 2.1.397
-  - dependency-name: Cake.Testing
-    versions:
-    - 1.0.0
+    - "> 2.0.174"


### PR DESCRIPTION
As there won't be anymore Cake 0.x releases and all 1.x releases of Cake.Issues will be API compatible we can cleanup Dependabot configuration. This also fixes version of MSBuild.StructuredLogger (see https://github.com/cake-contrib/Cake.Issues.MsBuild/issues/178).