### PR TITLE
Update MSBuild.StructuredLogger with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,3 @@ updates:
   - dependency-name: Cake.Issues.Testing
     versions:
     - "> 1.0.0, < 2"
-  - dependency-name: MSBuild.StructuredLogger
-    versions:
-    - "> 2.0.174"


### PR DESCRIPTION
Since we updated to latest version with #249 we can now update MSBuild.StructuredLogger again with Dependabot