### PR TITLE
(GH-286) Update target frameworks

### DIFF
--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -28,23 +28,17 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1\Cake.Issues.MsBuild.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.MsBuild.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.MsBuild.xml" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\StructuredLogger.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Microsoft.Build.Framework.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Microsoft.Build.Utilities.Core.dll" target="lib\netcoreapp3.1" />
-    <file src="net5.0\Cake.Issues.MsBuild.dll" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.MsBuild.pdb" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.MsBuild.xml" target="lib\net5.0" />
-    <file src="net5.0\StructuredLogger.dll" target="lib\net5.0" />
-    <file src="net5.0\Microsoft.Build.Framework.dll" target="lib\net5.0" />
-    <file src="net5.0\Microsoft.Build.Utilities.Core.dll" target="lib\net5.0" />
     <file src="net6.0\Cake.Issues.MsBuild.dll" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.MsBuild.pdb" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.MsBuild.xml" target="lib\net6.0" />
     <file src="net6.0\StructuredLogger.dll" target="lib\net6.0" />
     <file src="net6.0\Microsoft.Build.Framework.dll" target="lib\net6.0" />
     <file src="net6.0\Microsoft.Build.Utilities.Core.dll" target="lib\net6.0" />
+    <file src="net7.0\Cake.Issues.MsBuild.dll" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.MsBuild.pdb" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.MsBuild.xml" target="lib\net7.0" />
+    <file src="net7.0\StructuredLogger.dll" target="lib\net7.0" />
+    <file src="net7.0\Microsoft.Build.Framework.dll" target="lib\net7.0" />
+    <file src="net7.0\Microsoft.Build.Utilities.Core.dll" target="lib\net7.0" />
   </files>
 </package>

--- a/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>MsBuild support for the Cake.Issues Addin for Cake Build Automation System</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>


### PR DESCRIPTION
Updates target frameworks to .NET 6 and .NET 7.

Fixes #286 