### PR TITLE
(GH-297) Resolve CA issues to learn.microsoft.com

### DIFF
--- a/src/Cake.Issues.MsBuild.Tests/LogFileFormat/BinaryLogFileFormatTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/LogFileFormat/BinaryLogFileFormatTests.cs
@@ -199,7 +199,7 @@
                         "Cake.Issues.MsBuild.MsBuildIssuesProvider",
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
-                        .OfRule("CA2210", new Uri("https://www.google.com/search?q=\"CA2210:\"+site:docs.microsoft.com"))
+                        .OfRule("CA2210", new Uri("https://www.google.com/search?q=\"CA2210:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[16],
@@ -208,7 +208,7 @@
                         "Cake.Issues.MsBuild.MsBuildIssuesProvider",
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
-                        .OfRule("CA1014", new Uri("https://www.google.com/search?q=\"CA1014:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1014", new Uri("https://www.google.com/search?q=\"CA1014:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[17],
@@ -218,7 +218,7 @@
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
                         .InFile(@"src\ClassLibrary1\Class1.cs", 12)
-                        .OfRule("CA1822", new Uri("https://www.google.com/search?q=\"CA1822:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1822", new Uri("https://www.google.com/search?q=\"CA1822:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[18],
@@ -228,7 +228,7 @@
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
                         .InFile(@"src\ClassLibrary1\Class1.cs", 13)
-                        .OfRule("CA1804", new Uri("https://www.google.com/search?q=\"CA1804:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1804", new Uri("https://www.google.com/search?q=\"CA1804:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
             }
         }

--- a/src/Cake.Issues.MsBuild.Tests/LogFileFormat/XmlFileLoggerLogFileFormatTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/LogFileFormat/XmlFileLoggerLogFileFormatTests.cs
@@ -197,7 +197,7 @@
                         "Cake.Issues.MsBuild.MsBuildIssuesProvider",
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
-                        .OfRule("CA2210", new Uri("https://www.google.com/search?q=\"CA2210:\"+site:docs.microsoft.com"))
+                        .OfRule("CA2210", new Uri("https://www.google.com/search?q=\"CA2210:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[16],
@@ -206,7 +206,7 @@
                         "Cake.Issues.MsBuild.MsBuildIssuesProvider",
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
-                        .OfRule("CA1014", new Uri("https://www.google.com/search?q=\"CA1014:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1014", new Uri("https://www.google.com/search?q=\"CA1014:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[17],
@@ -216,7 +216,7 @@
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
                         .InFile(@"src\ClassLibrary1\Class1.cs", 12)
-                        .OfRule("CA1822", new Uri("https://www.google.com/search?q=\"CA1822:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1822", new Uri("https://www.google.com/search?q=\"CA1822:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[18],
@@ -226,7 +226,7 @@
                         "MSBuild")
                         .InProject(@"src\ClassLibrary1\ClassLibrary1.csproj", "ClassLibrary1")
                         .InFile(@"src\ClassLibrary1\Class1.cs", 13)
-                        .OfRule("CA1804", new Uri("https://www.google.com/search?q=\"CA1804:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1804", new Uri("https://www.google.com/search?q=\"CA1804:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
             }
 
@@ -249,7 +249,7 @@
                         "MSBuild")
                         .InProjectOfName(string.Empty)
                         .InFile(@"src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs", 1311)
-                        .OfRule("CA2201", new Uri("https://www.google.com/search?q=\"CA2201:\"+site:docs.microsoft.com"))
+                        .OfRule("CA2201", new Uri("https://www.google.com/search?q=\"CA2201:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
             }
 
@@ -317,7 +317,7 @@
                         "Cake.Issues.MsBuild.MsBuildIssuesProvider",
                         "MSBuild")
                         .InProjectOfName(string.Empty)
-                        .OfRule("CA1711", new Uri("https://www.google.com/search?q=\"CA1711:\"+site:docs.microsoft.com"))
+                        .OfRule("CA1711", new Uri("https://www.google.com/search?q=\"CA1711:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
             }
 
@@ -445,7 +445,7 @@
                             "MSBuild")
                         .InProjectOfName(string.Empty)
                         .InFile(@"src\Cake.Issues.MsBuild.Tests\MsBuildIssuesProviderTests.cs", 1311)
-                        .OfRule("CA2201", new Uri("https://www.google.com/search?q=\"CA2201:\"+site:docs.microsoft.com"))
+                        .OfRule("CA2201", new Uri("https://www.google.com/search?q=\"CA2201:\"+site:learn.microsoft.com"))
                         .WithPriority(IssuePriority.Warning));
                 IssueChecker.Check(
                     issues[1],

--- a/src/Cake.Issues.MsBuild.Tests/MsBuildRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/MsBuildRuleUrlResolverTests.cs
@@ -40,7 +40,7 @@
             }
 
             [Theory]
-            [InlineData("CA2201", "https://www.google.com/search?q=\"CA2201:\"+site:docs.microsoft.com")]
+            [InlineData("CA2201", "https://www.google.com/search?q=\"CA2201:\"+site:learn.microsoft.com")]
             [InlineData("SA1652", "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1652.md")]
             [InlineData("S1075", "https://rules.sonarsource.com/csharp/RSPEC-1075")]
             public void Should_Resolve_Url(string rule, string expectedUrl)

--- a/src/Cake.Issues.MsBuild/MsBuildRuleUrlResolver.cs
+++ b/src/Cake.Issues.MsBuild/MsBuildRuleUrlResolver.cs
@@ -21,7 +21,7 @@
             // .NET SDK analyzers
             this.AddUrlResolver(x =>
                 x.Category.ToUpperInvariant() == "CA" ?
-                    new Uri("https://www.google.com/search?q=%22" + x.Rule + ":%22+site:docs.microsoft.com") :
+                    new Uri("https://www.google.com/search?q=%22" + x.Rule + ":%22+site:learn.microsoft.com") :
                     null);
 
             // StyleCop analyzer rules


### PR DESCRIPTION
Resolves CA rules to learn.microsoft.com instead of docs.microsoft.com

Fixes #297 