### PR TITLE
Add specific addin for Cake Frosting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>cake-contrib/renovate-presets:cake-issues"
+    "github>cake-contrib/renovate-presets:cake-issues",
+    "github>cake-contrib/renovate-presets:frosting-addin"
   ]
 }

--- a/nuspec/nuget/Cake.Frosting.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.MsBuild.nuspec
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Cake.Frosting.Issues.MsBuild</id>
+    <title>Cake.Frosting.Issues.MsBuild</title>
+    <version>0.0.0</version>
+    <authors>BBT Software AG and contributors</authors>
+    <owners>bbtsoftware, pascalberger, cake-contrib</owners>
+    <summary>MsBuild support for the Cake.Issues addin for Cake Frosting</summary>
+    <description>
+The MsBuild support for the Cake.Issues addin for Cake allows you to read issues logged as warnings in a MsBuild log.
+
+This addin provides the aliases for reading MsBuild warnings and providing them to the Cake.Issues addin.
+It also requires the core Cake.Issues addin.
+
+There are also additional addins for generating reports or posting issues to pull requests.
+
+See the Project Site for an overview of the whole ecosystem of addins for working with issues in Cake scripts.
+
+
+NOTE:
+This is the version of the addin compatible with Cake Frosting.
+For addin compatible with Cake Script Runners see Cake.Issues.MsBuild.
+    </description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://cakeissues.net</projectUrl>
+    <icon>icon.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <repository type="git" url="https://github.com/cake-contrib/Cake.Issues.MsBuild.git"/>
+    <copyright>Copyright © BBT Software AG and contributors</copyright>
+    <tags>cake cake-addin cake-issues cake-issueprovider code-analysis linting msbuild</tags>
+    <releaseNotes>https://github.com/cake-contrib/Cake.Issues.MsBuild/releases/tag/3.0.0</releaseNotes>
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
+        <dependency id="MSBuild.StructuredLogger" version="2.2.100" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
+        <dependency id="MSBuild.StructuredLogger" version="2.2.100" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
+        <dependency id="MSBuild.StructuredLogger" version="2.2.100" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="icon.png" target="" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net6.0\Cake.Issues.MsBuild.dll" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net6.0\Cake.Issues.MsBuild.pdb" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net6.0\Cake.Issues.MsBuild.xml" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net7.0\Cake.Issues.MsBuild.dll" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net7.0\Cake.Issues.MsBuild.pdb" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net7.0\Cake.Issues.MsBuild.xml" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net8.0\Cake.Issues.MsBuild.dll" target="lib\net8.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net8.0\Cake.Issues.MsBuild.pdb" target="lib\net8.0" />
+    <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net8.0\Cake.Issues.MsBuild.xml" target="lib\net8.0" />
+  </files>
+</package>

--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -16,6 +16,10 @@ It also requires the core Cake.Issues addin.
 There are also additional addins for generating reports or posting issues to pull requests.
 
 See the Project Site for an overview of the whole ecosystem of addins for working with issues in Cake scripts.
+
+NOTE:
+This is the version of the addin compatible with Cake Script Runners.
+For addin compatible with Cake Frosting see Cake.Frosting.Issues.MsBuild.
     </description>
     <license type="expression">MIT</license>
     <projectUrl>https://cakeissues.net</projectUrl>

--- a/src/Cake.Issues.MsBuild/MsBuildIssuesAliases.cs
+++ b/src/Cake.Issues.MsBuild/MsBuildIssuesAliases.cs
@@ -4,6 +4,9 @@
 
     /// <summary>
     /// Contains functionality for reading warnings from MSBuild log files.
+    ///
+    /// NOTE: Use Cake.Issues.Reporting.Generic addin to use these aliases with Cake Script Runners and
+    /// Cake.Frosting.Issues.Reporting.Generic to use these aliases with Cake Frosting.
     /// </summary>
     [CakeAliasCategory(IssuesAliasConstants.MainCakeAliasCategory)]
     public static partial class MsBuildIssuesAliases


### PR DESCRIPTION
Add separate addin for Cake Frosting which contains a dependency to MSBuild.StructuredLogger instead of embedding dependencies.

Fixes #364 